### PR TITLE
Add StoreInfo, a zarr storage parameter class

### DIFF
--- a/drivetorch/__init__.py
+++ b/drivetorch/__init__.py
@@ -1,1 +1,2 @@
 from .drivetensor import DriveTensor
+from .storeinfo import init_storeinfo, StoreInfo, StoreInfoGenerator

--- a/drivetorch/__init__.py
+++ b/drivetorch/__init__.py
@@ -1,2 +1,2 @@
 from .drivetensor import DriveTensor
-from .storeinfo import init_storeinfo, StoreInfo, StoreInfoGenerator
+from .storeinfo import init_storeinfo, StoreInfo

--- a/drivetorch/drivetensor.py
+++ b/drivetorch/drivetensor.py
@@ -8,6 +8,7 @@ from zarr import open as zarr_open
 
 
 # from drivetorch.handler import DriveTensorHandler  # For trace
+from drivetorch.storeinfo import init_storeinfo, StoreInfo
 
 
 # TODO:
@@ -30,7 +31,7 @@ class DriveTensor:
     def __init__(
         self,
         data: ArrayLike,
-        store_data: dict = None,
+        store_data: Union[dict, str, StoreInfo] = None,
         from_numpy: bool = False,
         as_param: bool = False,
         # handler: Optional[DriveTensorHandler] = None,  # for trace
@@ -41,7 +42,11 @@ class DriveTensor:
 
         Args:
             data (`array_like`): Array-like data to wrap.
-            store_data (dict): Metadata for storage.
+            store_data (dict, str, or :class:`StoreInfo`\, optional): Parameters
+                for zarr storage. If a dict, it should include a `store` field
+                that will be used as a storage path. If input is a str, it will
+                be used as a storage path. If input is :class:`StoreInfo`, it
+                will be treated as a dict.
             from_numpy (bool, optional): Data will be initialized with
                 `torch.from_numpy` if True and with torch.as_tensor` if
                 False.
@@ -57,7 +62,7 @@ class DriveTensor:
             <DriveTensor(data=<zarr.core.Array (4,) int64 read-only>, store_data={'store': 'temp.data'})
         """
         assert data is not None
-        assert 'store' in store_data
+        store_data = init_storeinfo(store_data)
         # consider not creating tensor first to reduce the number of copies
         if isinstance(data, DriveTensor):
             tensor_data = tensor = data._tensor[:]

--- a/drivetorch/storeinfo.py
+++ b/drivetorch/storeinfo.py
@@ -11,9 +11,21 @@ def init_storeinfo(store=None, identifier=None, general=False, *args, **kwargs):
     if not already given.
 
     Args:
-        store (path-like or StoreInfo, optional): If of type :class:`StoreInfo`\,
-            then just returns store. Otherwise constructs a new instance of
-            :class:`StoreInfo` from given parameters.
+        store (path-like or StoreInfo, optional):
+            If of type :class:`StoreInfo`\, returns the given `store`\.
+            Otherwise constructs a new instance of :class:`StoreInfo` from
+            `path` and the given parameters.
+        identifier (str, optional): A str identifier to be passed to a new
+            instance of :class:`StoreInfo`\.
+            Only used if `general` is False.
+            Note that if `identifier` is None and `general` is True,
+            :class`StoreInfo` will set `identifier` using a process-wide
+            counter.
+            Defaults to None.
+        general (bool, optional): If True, outputs an instance of
+            :class:`ModelStoreInfo` and ignores `identifier`\. Otherwise,
+            outputs an instance of :class:`StoreInfo`\.
+            Defaults to False.
     """
     if isinstance(store, StoreInfo):
         return store
@@ -49,8 +61,8 @@ def parse_store_path(path=None, identifier=None, ignore_identifier=False):
     Args:
         path (Any, optional): Given path. If not None, returns `path`\.
             Otherwise, returns a path to a folder in .drivetorch_temp/
-        identifier (str, optional): Subdirectory to which drive info should be
-            stored. Ignored if None.
+        identifier (str or dict, optional): Subdirectory to which drive info
+            should be stored. Ignored if None.
             Defaults to None.
         ignore_identifier (bool, optional): If True, ignores any given
             `identifier` and does not create the identifier directory.
@@ -101,7 +113,17 @@ class StoreInfo(dict):
         Args:
             path (Any, optional): str or path object pointing to
                 directory in which tensors should be stored.
-                If not given, writes to a directory in .drivetorch_temp/
+                If not given, writes to .drivetorch_temp/[PID] where [PID] is
+                current process ID.
+            identifier (str, optional): A str identifier for the tensor stored
+                with this :class:`StoreInfo`\.
+                If None, a process-wide counter will be used as the identifier
+                (and the counter will be incremented).
+                Defaults to None.
+            ignore_identifier (bool, optional): Flag to ignore the identifier
+                argument. In general, this argument will only be used by
+                :class:`ModelStoreInfo` and can be ignored by the user.
+                Defaults to False.
         """
         super(StoreInfo, self).__init__()
         self.store_type = 'directory'  # currently, the only supported type
@@ -200,6 +222,11 @@ class ModelStoreInfo(StoreInfo):
         Args:
             identifier (str): The identifier to use for the new instance of
                 :class:`StoreInfo`\. Should be a nonempty string.
+
+        Returns:
+            :class:`StoreInfo`\: A :class:`StoreInfo` instance with keys
+            matching those of this object and an additional 'identifier' key
+            with the `identifier` argument as its value.
         """
         error = (
             "'identifier' should be a nonempty string but was "

--- a/drivetorch/storeinfo.py
+++ b/drivetorch/storeinfo.py
@@ -122,3 +122,20 @@ class StoreInfo(dict):
             raise RuntimeError(message)
         return super().__setattr__(attr, value, *args, **kwargs)
 
+
+class StoreInfoGenerator:
+    r"""
+    Helper class for generating multiple :class:`StoreInfo` instances for the same
+    model.
+    """
+
+    def __init__(self, store=None, **kwargs):
+        r"""
+        Initializes :class:`StoreInfoGenerator`\.
+        """
+        self._store = init_storeinfo(store, **kwargs)
+
+    def get_storeinfo(self, identifier):
+        store = deepcopy(self._store)
+        store['identifier'] = identifier
+        return store

--- a/drivetorch/storeinfo.py
+++ b/drivetorch/storeinfo.py
@@ -122,6 +122,13 @@ class StoreInfo(dict):
         # assume loading full array if not specified
         self['chunks'] = kwargs.get('chunks', False)
 
+    def __del__(self):  # delete if empty. or register atexit and delete all
+        try:
+            if self['temporary']:
+                self['store'].rmdir()
+        except Exception as e:
+            pass
+
     def _set_store(self):
         if self.store_type == 'directory':
             has_path = self.get('path') is not None
@@ -130,18 +137,6 @@ class StoreInfo(dict):
                 super().__setitem__('store', self['path'] / self['identifier'])
         else:
             raise NotImplementedError
-
-    def _get_hashpath(self):
-        if self.store_type == 'directory':
-            return self['path'] / 'hash_map.json'
-        else:
-            raise NotImplementedError
-
-
-    def __getitem__(self, item, *args, **kwargs):
-        if item == 'hashpath':
-            return self._get_hashpath()
-        return super().__getitem__(item, *args, **kwargs)
 
     def __setattr__(self, attr, value, *args, **kwargs):
         protected_attributes = [
@@ -196,9 +191,6 @@ class ModelStoreInfo(StoreInfo):
             ignore_identifier=True,
             **kwargs,
         )
-        #self._kwargs = deepcopy(kwargs)
-        #if store is not None
-        #self._kwargs.update({'store': store})
 
 
     def get_storeinfo(self, identifier):

--- a/drivetorch/storeinfo.py
+++ b/drivetorch/storeinfo.py
@@ -47,6 +47,12 @@ def parse_store_path(path=None, identifier=None, ignore_identifier=False):
     Args:
         path (Any, optional): Given path. If not None, returns `path`\.
             Otherwise, returns a path to a folder in .drivetorch_temp/
+        identifier (str, optional): Subdirectory to which drive info should be
+            stored. Ignored if None.
+            Defaults to None.
+        ignore_identifier (bool, optional): If True, ignores any given
+            `identifier` and does not create the identifier directory.
+            Defaults to False.
 
     Returns:
         path-like: Path to the directory to which :class:`DriveTensor`\s

--- a/drivetorch/storeinfo.py
+++ b/drivetorch/storeinfo.py
@@ -1,3 +1,9 @@
+r"""
+The `storeinfo` module has helper functions and classes for working with zarr
+storage.
+"""
+
+
 from copy import deepcopy
 from multiprocessing import current_process
 from pathlib import Path

--- a/drivetorch/storeinfo.py
+++ b/drivetorch/storeinfo.py
@@ -1,0 +1,124 @@
+from copy import deepcopy
+from multiprocessing import current_process
+from pathlib import Path
+
+
+def init_storeinfo(store=None, identifier=None, *args, **kwargs):
+    r"""
+    Convenience function for initializing a :class:`StoreInfo` instance
+    if not already given.
+
+    Args:
+        store (path-like or StoreInfo, optional): If of type :class:`StoreInfo`\,
+            then just returns store. Otherwise constructs a new instance of
+            :class:`StoreInfo` from given parameters.
+    """
+    if isinstance(store, StoreInfo):
+        return store
+    if isinstance(store, dict):
+        store.update(kwargs)
+        return StoreInfo(identifier=identifier, *args, **kwargs)
+    else:
+        type_error = (
+            "'store' should be of None, path-like, a dict, or StoreInfo. But "
+            f"passed as type: {type(store)}."
+        )
+        assert store is None or isinstance(store, str) or isinstance(store, Path), type_error
+        return StoreInfo(store, identifier=identifier, **kwargs)
+
+
+def parse_store_path(path=None, identifier=None):
+    r"""
+    Returns the given store path if not None. Otherwise, creates a
+    store path in .drivetorch_temp/ and creates the specified
+    directories if they do not exist.
+    This is a convenience function for creating temporary paths when
+    none are explicitly given.
+
+    Args:
+        path (Any, optional): Given path. If not None, returns `path`\.
+            Otherwise, returns a path to a folder in .drivetorch_temp/
+
+    Returns:
+        path-like: Path to the directory to which :class:`DriveTensor`\s
+            should be saved.
+    """
+    temporary = False
+    if identifier is None:
+        identifier = str(current_process().pid)
+    if path is None:
+        path = Path('.drivetorch_temp/')
+        temporary = True
+    elif not isinstance(path, Path):
+        path = Path(path)
+    (path / identifier).mkdir(parents=True, exist_ok=True)
+    return path, identifier, temporary
+
+
+class StoreInfo(dict):
+    r"""
+    Object for parsing and holding storage parameters for :class:`DriveTensor`\.
+    The current implementation will likely change as more features are added.
+
+    This object is used as kwargs for zarr storage.
+    """
+    def __init__(self, store=None, identifier=None, **kwargs):
+        r"""
+        Initializes :class:`StoreInfo`\.
+
+        Args:
+            store (Any, optional): str or path object pointing to
+                directory in which tensors should be stored.
+                If not given, writes to a directory in .drivetorch_temp/
+                Need to change `store` to `path`
+        """
+        super(StoreInfo, self).__init__()
+        self.store_type = 'directory'  # currently, the only supported type
+        path, identifier, temporary = parse_store_path(store, identifier)
+        self['path'] = path
+        self['identifier'] = identifier
+        self['temporary'] = temporary
+
+        # compression
+        self['compressor'] = kwargs.get('compressor', 'default')
+
+        # chunks
+        # assume loading full array if not specified
+        self['chunks'] = kwargs.get('chunks', False)
+
+    def _get_store(self):
+        return self['path'] / self['identifier']
+
+    def _get_hashpath(self):
+        if self.store_type == 'directory':
+            return self['path'] / 'hash_map.json'
+        else:
+            raise NotImplementedError
+
+    def __getattr__(self, attr, *args, **kwargs):
+        if attr == 'store':
+            return self._get_store()
+        elif attr == 'hashpath':
+            return self._get_hashpath()
+        return super().__getattr__(attr, *args, **kwargs)
+
+    def __getitem__(self, item, *args, **kwargs):
+        if item == 'store':
+            return self._get_store()
+        elif item == 'hashpath':
+            return self._get_hashpath()
+        return super().__getitem__(item, *args, **kwargs)
+
+    def __setattr__(self, attr, value, *args, **kwargs):
+        protected_attributes = [
+            'store',
+            'hashpath',
+        ]
+        if attr in protected_attributes:
+            message = (
+                f"The '{attr}' attribute of {self.__class__.__name__} cannot "
+                "be set directly."
+            )
+            raise RuntimeError(message)
+        return super().__setattr__(attr, value, *args, **kwargs)
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+
+
+from utils import temp_cwd
+
+
+@pytest.fixture(autouse=True)
+def use_temp_cwd(tmp_path_factory):
+    pth = tmp_path_factory.mktemp('temp')
+    with temp_cwd(pth):
+        yield
+    return None
+

--- a/tests/test_drivetensor.py
+++ b/tests/test_drivetensor.py
@@ -10,26 +10,23 @@ class TestDriveTensor:
     r"""
     :class:`DriveTensor` Unit tests.
     """
-    @staticmethod
-    def add_store_path(store_data, tmp_path):
-        if 'store' in store_data:
-            store_data['store'] = tmp_path / store_data['store']
-        return store_data
 
     @pytest.mark.parametrize(
         'data,store_data',
         [
             (np.arange(3).astype('float'), {'store': 'data'}),
+            (np.arange(9).reshape(1, 3, 1, 3).astype('float'), 'data'),
             (np.random.normal(0, 1, size=(5, 10)), {'store': 'data'}),
+            (np.random.normal(0, 1, size=(5, 10)), None),
         ]
     )
-    def test_init_success(self, data, store_data, tmp_path):
-        self.add_store_path(store_data, tmp_path)
-        DriveTensor(
+    def test_init_success(self, data, store_data):
+        tensor = DriveTensor(
             data=data,
             store_data=store_data,
         )
-        assets = os.listdir(store_data['store'])
+        pth = tensor._tensor.store.dir_path()
+        assets = os.listdir(pth)
         assert len(assets) > 0
         assert '.zarray' in assets
 
@@ -37,11 +34,10 @@ class TestDriveTensor:
         'data,store_data',
         [
             (None, {'store': 'data'}),
-            (np.random.normal(0, 1, size=(5, 10)), dict()),
+            (None, dict()),
         ]
     )
-    def test_init_fail(self, data, store_data, tmp_path):
-        self.add_store_path(store_data, tmp_path)
+    def test_init_fail(self, data, store_data):
         with pytest.raises(AssertionError) as e_info:
             DriveTensor(
                 data=data,

--- a/tests/test_storeinfo.py
+++ b/tests/test_storeinfo.py
@@ -6,8 +6,8 @@ from multiprocessing import current_process
 from drivetorch import (
     init_storeinfo,
     StoreInfo,
-    StoreInfoGenerator,
 )
+from drivetorch.storeinfo import ModelStoreInfo
 
 
 
@@ -57,16 +57,16 @@ class TestStoreInfo:
             assert attribute not in store_info
         assert store_info.store == store_info['path'] / store_info['identifier']
 
-class TestStoreInfoGenerator:
+class TestModelStoreInfo:
     r"""
-    :class:`StoreInfoGenerator` unit tests.
+    :class:`ModelStoreInfo` unit tests.
     """
     @pytest.mark.parametrize(
         'store',
         [None, 'storeinfo_test']
     )
     def test_init(self, store):
-        StoreInfoGenerator(store=store)
+        ModelStoreInfo(store=store)
 
     @pytest.mark.parametrize(
         'store,identifier',
@@ -76,8 +76,8 @@ class TestStoreInfoGenerator:
         ]
     )
     def test_get_storeinfo(self, store, identifier):
-        storeinfo_generator = StoreInfoGenerator(store=store)
-        storeinfo = storeinfo_generator.get_storeinfo(identifier=identifier)
+        modelstoreinfo = ModelStoreInfo(store=store)
+        storeinfo = modelstoreinfo.get_storeinfo(identifier=identifier)
         assert storeinfo['identifier'] == identifier
 
     @pytest.mark.parametrize(
@@ -85,6 +85,6 @@ class TestStoreInfoGenerator:
         [None, 'storeinfo_test']
     )
     def test_get_storeinfo_fail(self, store):
-        storeinfo_generator = StoreInfoGenerator(store=store)
+        modelstoreinfo = ModelStoreInfo(store=store)
         with pytest.raises(TypeError):
-            storeinfo = storeinfo_generator.get_storeinfo()
+            storeinfo = modelstoreinfo.get_storeinfo()

--- a/tests/test_storeinfo.py
+++ b/tests/test_storeinfo.py
@@ -1,0 +1,90 @@
+import pytest
+import os
+from multiprocessing import current_process
+
+
+from drivetorch import (
+    init_storeinfo,
+    StoreInfo,
+    StoreInfoGenerator,
+)
+
+
+
+class TestStoreInfo:
+    r"""
+    :class:`StoreInfo` unit tests.
+    """
+    @pytest.mark.parametrize(
+        'store',
+        [None, 'storeinfo_test']
+    )
+    def test_init(self, store):
+        StoreInfo(store=store)
+
+    @pytest.mark.parametrize(
+        'store,pre_init',
+        [
+            (None, False),
+            (None, True),
+            ('storeinfo_test', False),
+            ('storeinfo_test', True),
+        ]
+    )
+    def test_constructor(self, store, pre_init):
+        if pre_init:
+            store = StoreInfo(store=store)
+        store_info = init_storeinfo(store=store)
+        assert isinstance(store_info, StoreInfo)
+
+    def test_temp_storage(self):
+        # get cwd, change and run, change back
+        store = init_storeinfo()
+        files = os.listdir('.')
+        assert files == ['.drivetorch_temp']
+        pid_directory = os.listdir('.drivetorch_temp/')
+        assert pid_directory == [str(current_process().pid)]
+        assert store['temporary']
+
+    def test_attributes(self):
+        store = 'tmp_store'
+        store_info = StoreInfo(store=store)
+        attributes = ['path', 'identifier', 'temporary']
+        for attribute in attributes:
+            assert attribute in store_info
+        non_attributes = ['store']
+        for attribute in non_attributes:
+            assert attribute not in store_info
+        assert store_info.store == store_info['path'] / store_info['identifier']
+
+class TestStoreInfoGenerator:
+    r"""
+    :class:`StoreInfoGenerator` unit tests.
+    """
+    @pytest.mark.parametrize(
+        'store',
+        [None, 'storeinfo_test']
+    )
+    def test_init(self, store):
+        StoreInfoGenerator(store=store)
+
+    @pytest.mark.parametrize(
+        'store,identifier',
+        [
+            (None,'param1'),
+            ('storeinfo_test','param1'),
+        ]
+    )
+    def test_get_storeinfo(self, store, identifier):
+        storeinfo_generator = StoreInfoGenerator(store=store)
+        storeinfo = storeinfo_generator.get_storeinfo(identifier=identifier)
+        assert storeinfo['identifier'] == identifier
+
+    @pytest.mark.parametrize(
+        'store',
+        [None, 'storeinfo_test']
+    )
+    def test_get_storeinfo_fail(self, store):
+        storeinfo_generator = StoreInfoGenerator(store=store)
+        with pytest.raises(TypeError):
+            storeinfo = storeinfo_generator.get_storeinfo()

--- a/tests/test_storeinfo.py
+++ b/tests/test_storeinfo.py
@@ -49,13 +49,10 @@ class TestStoreInfo:
     def test_attributes(self):
         store = 'tmp_store'
         store_info = StoreInfo(store=store)
-        attributes = ['path', 'identifier', 'temporary']
+        attributes = ['path', 'identifier', 'temporary', 'store']
         for attribute in attributes:
             assert attribute in store_info
-        non_attributes = ['store']
-        for attribute in non_attributes:
-            assert attribute not in store_info
-        assert store_info.store == store_info['path'] / store_info['identifier']
+        assert store_info['store'] == store_info['path'] / store_info['identifier']
 
 class TestModelStoreInfo:
     r"""

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,12 @@
+import os
+import contextlib
+
+
+@contextlib.contextmanager
+def temp_cwd(x):
+    d = os.getcwd()
+    os.chdir(x)
+    try:
+        yield
+    finally:
+        os.chdir(d)


### PR DESCRIPTION
This PR:
1. Adds store info classes (StoreInfo and ModelStoreInfo) and helper functions
2. Updates DriveTensor for the new store info classes
3. Updates how paths are handled with pytest

---
(1) Two dict subclasses for parsing zarr storage parameters and a helper constructor function will be introduced.

StoreInfo subclasses dict and accepts 'path', 'identifier', and 'ignore_identifier' arguments.
StoreInfo will be unpacked with ** when calling zarr.open and provides additional preparsing.
'path' is the path to the directory the tensor will be saved to.
'identifier' is the name of the zarr store. If None, a process-unique counter is used as the identifier.
'ignore_identifier' allows identifier to be None and is used by ModelStoreInfo.

ModelStoreInfo subclasses StoreInfo and accepts only the 'path' argument.
It is intended to be used as a shared StoreInfo for multiple tensors (specifically for multiple parameter tensors from the same model) by calling the get_storeinfo(identifier) method to generate a new StoreInfo instance.

The constructor init_storeinfo takes 'store', 'identifier', and 'general' arguments (and *args and **kwargs).
'store' can be path-like, a dict, or StoreInfo.
'identifier' can be None or a str.
'general' should be a bool. If general is True, returns a ModelStoreInfo object. Otherwise, returns a StoreInfo object.


---
(2) DriveTensor's type signature will be updated to include StoreInfo and its init is changed to use init_storeinfo.

---
(3) All pytest tests will be run in a temporary directory to avoid having to work with tmp_path in every test function.