### PR TITLE
Add model storing and loading functions

### DIFF
--- a/drivetorch/__init__.py
+++ b/drivetorch/__init__.py
@@ -1,2 +1,3 @@
 from .drivetensor import DriveTensor
 from .storeinfo import init_storeinfo, StoreInfo
+from .store_load import store

--- a/drivetorch/__init__.py
+++ b/drivetorch/__init__.py
@@ -1,3 +1,3 @@
 from .drivetensor import DriveTensor
 from .storeinfo import init_storeinfo, StoreInfo
-from .store_load import store
+from .store_load import load, store

--- a/drivetorch/store_load.py
+++ b/drivetorch/store_load.py
@@ -81,6 +81,25 @@ def load(
         model: Module,
         storeinfo: Union[str, dict, ModelStoreInfo],
 ):
+    r"""
+    Load stored weights.
+
+    Args:
+        model (`torch.nn.Module`): An initialized model.
+        storeinfo (str or dict or :class:`ModelStoreInfo`, optional):
+            Parameters for zarr storage from which all parameter and
+            buffer weights will be loaded.
+            If a str, dict, or ModelStoreInfo, it will be used to create
+            an instance of :class:`ModelStoreInfo`\.
+            If None, model parameters and buffers will be loaded from
+            [CWD]/.drivetorch_temp/[PID]/ where [CWD] is the current
+            working directory and [PID] is the process ID.
+            Defaults to None.
+            Note that using None for the storeinfo argument will only
+            work if the weights to be loaded were stored from the same
+            process and only one unique model needs to be stored and
+            loaded.
+    """
     model_storeinfo = init_storeinfo(storeinfo, general=True)
     metadata = model_storeinfo.load_metadata()
     named_parameters = list(model.named_parameters()) + list(model.named_buffers())

--- a/drivetorch/store_load.py
+++ b/drivetorch/store_load.py
@@ -1,0 +1,77 @@
+r"""
+The :mod:`store_load` module contains functions for storing (and
+eventually loading) PyTorch models to a drive.
+
+Currently, the only implemented storage function is :func:`store`\, but
+it requires loading the entire model before it can be stored.
+Therefore, models may need to be stored and then transfered to low-
+memory devices.
+
+We will release several optimizations in the future to help reduce the
+memory usage in the initial store and load functions.
+"""
+
+
+import zarr
+from pathlib import Path
+import json
+from copy import deepcopy
+from torch.nn import Module
+from typing import Optional, Union
+from hashlib import sha256
+from pickle import dumps
+
+
+# from drivetorch.handler import DriveTensorHandler
+from drivetorch.drivetensor import DriveTensor
+from drivetorch.storeinfo import (
+    init_storeinfo,
+    ModelStoreInfo,
+)
+from drivetorch.utils import hash_tensor, set_nested
+
+
+# TODO:
+#    - Add support for saving the handler object
+#    - Add TempParameter support (and as a context manager)
+#    - (Later) add custom pickler
+
+
+def store(
+        model: Module,
+        storeinfo: Optional[Union[str, dict, ModelStoreInfo]] = None,
+        # handler: Optional[DriveTensorHandler] = None,
+        **kwargs,
+):
+    r"""
+    Store a PyTorch model.
+
+    Args:
+        model (`torch.nn.Module`): The model to store.
+        storeinfo (str or dict or :class:`ModelStoreInfo`, optional):
+            Parameters for zarr storage, to be shared for all model
+            parameters and buffers.
+            If a str, dict, or ModelStoreInfo, it will be used to create
+            an instance of :class:`ModelStoreInfo`\.
+            If None, model parameters and buffers will be saved to a
+            local .drivetorch_temp directory.
+            Defaults to None.
+    """
+    model_storeinfo = init_storeinfo(storeinfo, general=True)
+
+    named_parameters = list(model.named_parameters()) + list(model.named_buffers())
+    hash_map = dict()
+    for name, parameter in named_parameters:
+        param_hash = hash_tensor(parameter[:])
+        hash_map[name] = param_hash
+        storeinfo_instance = model_storeinfo.get_storeinfo(param_hash)
+        drive_tensor = DriveTensor(
+            data=parameter,
+            store_data=storeinfo_instance,
+            # handler=handler,
+            as_param=True,
+        )
+        set_nested(model, name.split('.'), drive_tensor)
+    metadata = {'hash_map': hash_map}
+    model_storeinfo.store_metadata(metadata)
+    return model

--- a/drivetorch/store_load.py
+++ b/drivetorch/store_load.py
@@ -1,6 +1,6 @@
 r"""
-The :mod:`store_load` module contains functions for storing (and
-eventually loading) PyTorch models to a drive.
+The :mod:`store_load` module contains functions for storing and loading
+PyTorch models to a drive.
 
 Currently, the only implemented storage function is :func:`store`\, but
 it requires loading the entire model before it can be stored.

--- a/drivetorch/store_load.py
+++ b/drivetorch/store_load.py
@@ -75,3 +75,21 @@ def store(
     metadata = {'hash_map': hash_map}
     model_storeinfo.store_metadata(metadata)
     return model
+
+
+def load(
+        model: Module,
+        storeinfo: Union[str, dict, ModelStoreInfo],
+):
+    model_storeinfo = init_storeinfo(storeinfo, general=True)
+    metadata = model_storeinfo.load_metadata()
+    named_parameters = list(model.named_parameters()) + list(model.named_buffers())
+    for name, parameter in named_parameters:
+        param_hash = metadata['hash_map'][name]
+        storeinfo_instance = model_storeinfo.get_storeinfo(param_hash)
+        drive_tensor = DriveTensor(
+            store_data=storeinfo_instance,
+            from_store=True,
+            as_param=True,
+        )
+        set_nested(model, name.split('.'), drive_tensor)

--- a/drivetorch/storeinfo.py
+++ b/drivetorch/storeinfo.py
@@ -241,3 +241,24 @@ class ModelStoreInfo(StoreInfo):
         assert isinstance(identifier, str) and identifier != '', error
         store = deepcopy(self)
         return init_storeinfo(identifier=identifier, **store)
+
+    def store_metadata(self, metadata: dict):
+        r"""
+        Save metadata.
+        If the :attr:`store_type` attribute is 'directory', this will save a
+        metadata file to the directory specified by this object's :attr:`path`
+        attribute.
+
+        Args:
+            metadata (dict): The metadata to store.
+
+        Note:
+            :meth:`store_metadata` and :meth:`load_metadata` may be changed in
+            the future to just use a single method that returns a metadata
+            class.
+        """
+        if self.store_type == 'directory':
+            with open(self['path'] / 'metadata.json', 'w') as f:
+                json.dump(metadata, f, indent=2)
+        else:
+            raise NotImplementedError

--- a/drivetorch/storeinfo.py
+++ b/drivetorch/storeinfo.py
@@ -262,3 +262,25 @@ class ModelStoreInfo(StoreInfo):
                 json.dump(metadata, f, indent=2)
         else:
             raise NotImplementedError
+
+    def load_metadata(self):
+        r"""
+        Load metadata.
+        If the :attr:`store_type` attribute is 'directory', this will load the
+        metadata file found in the directory specified by this object's
+        :attr:`path` attribute.
+
+        Returns:
+            dict: Model metadata
+
+        Note:
+            :meth:`store_metadata` and :meth:`load_metadata` may be changed in
+            the future to just use a single method that returns a metadata
+            class.
+        """
+        if self.store_type == 'directory':
+            with open(self['path'] / 'metadata.json', 'rb') as f:
+                metadata = json.load(f)
+        else:
+            raise NotImplementedError
+        return metadata

--- a/drivetorch/storeinfo.py
+++ b/drivetorch/storeinfo.py
@@ -5,6 +5,7 @@ storage.
 
 
 from copy import deepcopy
+from typing import Dict
 from multiprocessing import current_process
 from pathlib import Path
 import json
@@ -249,7 +250,7 @@ class ModelStoreInfo(StoreInfo):
         store = deepcopy(self)
         return init_storeinfo(identifier=identifier, **store)
 
-    def store_metadata(self, metadata: dict):
+    def store_metadata(self, metadata: Dict):
         r"""
         Save metadata.
         If the :attr:`store_type` attribute is 'directory', this will save a

--- a/drivetorch/storeinfo.py
+++ b/drivetorch/storeinfo.py
@@ -37,7 +37,10 @@ def init_storeinfo(store=None, identifier=None, general=False, *args, **kwargs):
         return store
     if isinstance(store, dict):
         store.update(kwargs)
-        return StoreInfo(identifier=identifier, *args, **kwargs)
+        if general:
+            return ModelStoreInfo(identifier=identifier, *args, **kwargs)
+        else:
+            return StoreInfo(identifier=identifier, *args, **kwargs)
     else:
         type_error = (
             "'store' should be of None, path-like, a dict, or StoreInfo. But "
@@ -221,13 +224,15 @@ class ModelStoreInfo(StoreInfo):
         )
 
 
-    def get_storeinfo(self, identifier):
+    def get_storeinfo(self, identifier=None):
         r"""
         Returns an instance of :class:`StoreInfo` with the given identifier.
 
         Args:
-            identifier (str): The identifier to use for the new instance of
-                :class:`StoreInfo`\. Should be a nonempty string.
+            identifier (str, optional): The identifier to use for the new
+                instance of :class:`StoreInfo`\.
+                If None, the process-wide identifier counter is used.
+                Defaults to None.
 
         Returns:
             :class:`StoreInfo`\: A :class:`StoreInfo` instance with keys
@@ -235,10 +240,12 @@ class ModelStoreInfo(StoreInfo):
             with the `identifier` argument as its value.
         """
         error = (
-            "'identifier' should be a nonempty string but was "
+            "'identifier' should be a nonempty string or None but was "
             f"'{identifier}'"
         )
-        assert isinstance(identifier, str) and identifier != '', error
+        is_none = identifier is None
+        is_nonempty_str = isinstance(identifier, str) and identifier != ''
+        assert is_none or is_nonempty_str, error
         store = deepcopy(self)
         return init_storeinfo(identifier=identifier, **store)
 

--- a/drivetorch/utils.py
+++ b/drivetorch/utils.py
@@ -6,14 +6,14 @@ General utility functions.
 from torch import Tensor, from_numpy
 from torch.nn import Module, Parameter
 from numpy import ndarray
-from typing import Union
+from typing import List, Union
 from hashlib import sha256
 from pickle import dumps
 
 
 def set_nested(
         module: Module,
-        atts: list[str],
+        atts: List[str],
         tensor: Union[Tensor, Parameter],
 ):
     r"""

--- a/drivetorch/utils.py
+++ b/drivetorch/utils.py
@@ -1,0 +1,54 @@
+r"""
+General utility functions.
+"""
+
+
+from torch import Tensor, from_numpy
+from torch.nn import Module, Parameter
+from numpy import ndarray
+from typing import Union
+from hashlib import sha256
+from pickle import dumps
+
+
+def set_nested(
+        module: Module,
+        atts: list[str],
+        tensor: Union[Tensor, Parameter],
+):
+    r"""
+    Set a nested parameter or buffer with `tensor`\.
+
+    Args:
+        module (Module): Module with a descendent parameter or buffer
+            to set.
+        atts (list[str]): List of nested child names to specify a
+            descendent parameter or buffer.
+            For example, the list ['attention', 'linear_1', 'weight']
+            will update the weight parameter or buffer of the
+            module.attention.linear_1 submodule.
+        tensor (Tensor or Parameter): The tensor with which to update
+            the parameter or buffer.
+    """
+    placeholder = module
+    for att in atts[:-1]:
+        placeholder = getattr(placeholder, att)
+    setattr(placeholder, atts[-1], tensor)
+
+
+def hash_tensor(data: Union[ndarray, Tensor, Parameter]):
+    r"""
+    Hash a tensor-like object.
+
+    First convert the data to a str with `pickle.dumps` then hash with
+    `hashlib.sha256`\.
+
+    Args:
+        data (ndarray or Tensor or Parameter): The data to hash.
+
+    Returns:
+        str: Hash of the input data.
+    """
+    if isinstance(data, ndarray):
+        data = from_numpy(data)
+    return sha256(dumps(data[:])).hexdigest()

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,0 +1,56 @@
+import pytest
+import torch
+import torch.nn as nn
+
+
+from drivetorch import (
+    store,
+    load,
+)
+
+
+from utils import temp_cwd
+
+
+class SimpleModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.net = nn.Linear(10, 10)
+        self.test_param = nn.Parameter(torch.tensor([1.]))
+        self.register_buffer('test_buffer', torch.tensor([1.]))
+
+    def forward(self, x):
+        return self.net(x) + self.test_buffer
+
+
+class TestLoad:
+    r"""
+    :func:`load` unit tests.
+    """
+    @staticmethod
+    def reset_model_weights(model):
+        for parameter in model.parameters():
+            nn.init.normal_(parameter)
+
+    @pytest.mark.parametrize(
+        'storeinfo',
+        [
+            'model_to_load',  # str storeinfo
+            {'path': 'model_to_load'},  # dict storeinfo
+            None,  # default directory (based on PID) should work
+        ]
+    )
+    @torch.no_grad()
+    def test_load(self, storeinfo):
+        model_1 = SimpleModel()
+        model_2 = SimpleModel()
+        self.reset_model_weights(model_2)
+
+        tensor_in = torch.randn((1, 10))
+        tensor_out = model_1(tensor_in)
+
+        store(model_1, storeinfo=storeinfo)
+        del model_1
+        load(model_2, storeinfo=storeinfo)
+
+        assert torch.allclose(model_2(tensor_in), tensor_out)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,52 @@
+import pytest
+import os
+import zarr
+import torch
+import torch.nn as nn
+import json
+from pathlib import Path
+
+
+from drivetorch import (
+    store,
+)
+
+
+class SimpleModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.net = nn.Linear(10, 10)
+        self.register_buffer('test_buffer', torch.tensor([1]))
+
+    def forward(self, x):
+        return self.net(x) + self.test_buffer
+
+
+class TestStore:
+    r"""
+    :func:`store` unit tests.
+    """
+    def test_store_directory(self):
+        model = SimpleModel()
+        model_path = Path('model_test')
+        store(model, storeinfo=model_path)
+        assets = os.listdir(model_path)
+        assert 'metadata.json' in assets
+        with open(model_path / 'metadata.json', 'rb') as f:
+            hash_map = json.load(f)['hash_map']
+        for hash_value in hash_map.values():
+            assert hash_value in assets
+
+    def test_store_data(self):
+        model = SimpleModel()
+        model_path = Path('model_test')
+        store(model, storeinfo=model_path)
+        with open(model_path / 'metadata.json', 'rb') as f:
+            hash_map = json.load(f)['hash_map']
+
+        net_weight = zarr.open(model_path / hash_map['net.weight'], 'r')
+        assert torch.allclose(torch.from_numpy(net_weight[:]), model.net.weight)
+        net_bias = zarr.open(model_path / hash_map['net.bias'], 'r')
+        assert torch.allclose(torch.from_numpy(net_bias[:]), model.net.bias)
+        test_buffer = zarr.open(model_path / hash_map['test_buffer'], 'r')
+        assert torch.allclose(torch.from_numpy(test_buffer[:]), model.test_buffer)

--- a/tests/test_storeinfo.py
+++ b/tests/test_storeinfo.py
@@ -78,10 +78,22 @@ class TestModelStoreInfo:
         assert storeinfo['identifier'] == identifier
 
     @pytest.mark.parametrize(
+        'store,identifier',
+        [
+            (None, ''),
+            (None, True),
+            ('storeinfo_test', 1),
+        ]
+    )
+    def test_get_storeinfo_fail(self, store, identifier):
+        modelstoreinfo = ModelStoreInfo(store=store)
+        with pytest.raises(AssertionError):
+            storeinfo = modelstoreinfo.get_storeinfo(identifier)
+
+    @pytest.mark.parametrize(
         'store',
         [None, 'storeinfo_test']
     )
-    def test_get_storeinfo_fail(self, store):
+    def test_get_storeinfo_default(self, store):
         modelstoreinfo = ModelStoreInfo(store=store)
-        with pytest.raises(TypeError):
-            storeinfo = modelstoreinfo.get_storeinfo()
+        storeinfo = modelstoreinfo.get_storeinfo()


### PR DESCRIPTION
Add basic storing and loading functions:
- Add store_load.store
  - (Args: model, storeinfo) Stores a model to the store specified by storeinfo. Saves each parameter and buffer by its tensor data cache and saves a metadata table that maps parameter and buffer names to caches.
- Add store_load.load
  - (Args: model, storeinfo) Loads weights for the model from the previously saved weights specified by storeinfo.
- Update drivetensor and storeinfo modules to work with loading and saving.
